### PR TITLE
Add Install command to LLFSMGenerate

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,7 @@
 `llfsmgenerate` is a command-line utility for transforming and compiling LLFSM formats that use the `VHDL`
 Hardware Description Language.
 This program allows the transformation between [VHDL LLFSMs](https://github.com/mipalgu/VHDLMachines) and
-other standard Javascript models, such as the [VHDL LLFSM editor](https://github.com/Morgan2010/editor)
-(to be released soon) that utilises *React*.
+other standard Javascript models, such as the VHDL LLFSM editor (to be released soon) that utilises *React*.
 In addition to this support, the program can generate the relative `vhd` files for standard execution and
 formal verification via Kripke structure generation.
 

--- a/README.md
+++ b/README.md
@@ -32,6 +32,49 @@ program within `/usr/local/`:
 install -m 0755 .build/release/llfsmgenerate /usr/local/bin
 ```
 
+The `llfsmgenerate` binary allows the transformation of LLFSM models that contain VHDL code within their
+state actions. Most LLFSMs are created using an editor that places an easily parsable format within the
+LLFSM directory. This format is very easy to parse using Javascript, however, it does not provide type
+information that is extremely useful in formal verification and code generation. To generate VHDL code for a
+given LLFSM, we need to first convert it from the Javascript-like format into the format that our
+[code generator](https://github.com/mipalgu/VHDLMachines) understands. This is done by using the command:
+
+```shell
+llfsmgenerate model <path_to_LLFSM_folder>
+```
+
+> [!IMPORTANT]
+> Please make sure the LLFSM path contains a `.machine` extension.
+
+This command creates the type-aware model that our
+[code generator](https://github.com/mipalgu/VHDLMachines) interprets.
+
+Once this model is generated, we can then create the VHDL source files by using:
+
+```shell
+llfsmgenerate vhdl <path_to_LLFSM_folder>
+```
+
+This command creates the `.vhd` files located in `<path_to_LLFSM_folder>/build/vhdl`. We can also create
+the Kripke structure generator that creates graph structures for formal verification.
+
+```shell
+llfsmgenerate vhdl --include-kripke-structure <path_to_LLFSM_folder>
+```
+
+We may now copy our vhdl files into a directory that we can utilise for HDL projects. We have provided
+a command called `install` to make this simpler.
+
+```shell
+llfsmgenerate install <path_to_LLFSM_folder> <path_to_install_location>
+```
+
+You may also specify a vivado project location by passing the `--vivado` flag.
+
+```shell
+llfsmgenerate install <path_to_LLFSM_folder> --vivado <path_to_vivado_project_directory>
+```
+
 Please see the *help* section of the binary for a complete list of parameters and sub-commands.
 ```shell
 llfsmgenerate --help
@@ -47,6 +90,7 @@ SUBCOMMANDS:
   model                   A utility for converting LLFSM formats.
   vhdl                    A utility for generating VHDL source files from LLFSM definitions.
   clean                   Clean the generated source files from the machine.
+  install                 Install the VHDL files into a specified directory.
 
   See 'llfsmgenerate help <subcommand>' for detailed help.
 ```

--- a/Sources/MachineGenerator/GenerationError.swift
+++ b/Sources/MachineGenerator/GenerationError.swift
@@ -57,6 +57,9 @@
 /// Errors thrown by the generator.
 enum GenerationError: Error, Equatable, Codable, Hashable, Sendable {
 
+    /// An error with the current machine.
+    case invalidMachine(message: String)
+
     /// An error during the model generation process.
     case invalidExportation(message: String)
 
@@ -65,6 +68,9 @@ enum GenerationError: Error, Equatable, Codable, Hashable, Sendable {
 
     /// An error during the Machine generation process.
     case invalidGeneration(message: String)
+
+    /// An error with user input.
+    case invalidInput(message: String)
 
     /// An invalid layout for new machine.
     case invalidLayout(message: String)

--- a/Sources/MachineGenerator/GenerationError.swift
+++ b/Sources/MachineGenerator/GenerationError.swift
@@ -55,7 +55,7 @@
 // 
 
 /// Errors thrown by the generator.
-enum GenerationError: Error, Equatable, Codable, Hashable, Sendable {
+enum GenerationError: Error, Equatable, Codable, Hashable, Sendable, CustomStringConvertible {
 
     /// An error with the current machine.
     case invalidMachine(message: String)
@@ -74,5 +74,13 @@ enum GenerationError: Error, Equatable, Codable, Hashable, Sendable {
 
     /// An invalid layout for new machine.
     case invalidLayout(message: String)
+
+    var description: String {
+        switch self {
+        case let .invalidMachine(message), let .invalidExportation(message), let .invalidFormat(message),
+        let .invalidGeneration(message), let .invalidInput(message), let .invalidLayout(message):
+            return "\(message)"
+        }
+    }
 
 }

--- a/Sources/MachineGenerator/InstallCommand.swift
+++ b/Sources/MachineGenerator/InstallCommand.swift
@@ -1,0 +1,157 @@
+// InstallCommand.swift
+// LLFSMGenerate
+// 
+// Created by Morgan McColl.
+// Copyright © 2024 Morgan McColl. All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 
+// 1. Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+// 
+// 2. Redistributions in binary form must reproduce the above
+//    copyright notice, this list of conditions and the following
+//    disclaimer in the documentation and/or other materials
+//    provided with the distribution.
+// 
+// 3. All advertising materials mentioning features or use of this
+//    software must display the following acknowledgement:
+// 
+//    This product includes software developed by Morgan McColl.
+// 
+// 4. Neither the name of the author nor the names of contributors
+//    may be used to endorse or promote products derived from this
+//    software without specific prior written permission.
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER
+// OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// 
+// -----------------------------------------------------------------------
+// This program is free software; you can redistribute it and/or
+// modify it under the above terms or under the terms of the GNU
+// General Public License as published by the Free Software Foundation;
+// either version 2 of the License, or (at your option) any later version.
+// 
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+// 
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, see http://www.gnu.org/licenses/
+// or write to the Free Software Foundation, Inc., 51 Franklin Street,
+// Fifth Floor, Boston, MA  02110-1301, USA.
+
+import ArgumentParser
+import Foundation
+
+/// A command that install generated files into a specified directory.
+struct InstallCommand: ParsableCommand {
+
+    /// The configuration of this command.
+    static var configuration = CommandConfiguration(
+        commandName: "install",
+        abstract: "Install the VHDL files into a specified directory."
+    )
+
+    /// That path to the install location.
+    @Argument(help: "The directory to install the generated files into.", completion: .directory)
+    var installPath: String
+
+    /// The path to the machine to install.
+    @OptionGroup var path: PathArgument
+
+    /// Whether `installPath` is a vivado project directory.
+    @Flag(help: "Specifies that the install path is a vivado project directory.")
+    var vivado = false
+
+    var installURL: URL {
+        URL(fileURLWithPath: installPath, isDirectory: true)
+    }
+
+    /// The main entry point for this command.
+    /// - Throws: ``GenerationError``.
+    func run() throws {
+        guard self.path.path.hasSuffix(".machine") else {
+            throw GenerationError.invalidMachine(message: "The path provided is not a machine.")
+        }
+        let manager = FileManager.default
+        var isDirectory: ObjCBool = false
+        guard
+            manager.fileExists(atPath: self.path.path, isDirectory: &isDirectory), isDirectory.boolValue
+        else {
+            throw GenerationError.invalidMachine(message: "The path provided is not a valid machine.")
+        }
+        isDirectory = false
+        guard manager.fileExists(atPath: installPath, isDirectory: &isDirectory), isDirectory.boolValue else {
+            throw GenerationError.invalidInput(message: "The install directory is incorrect.")
+        }
+        let buildFolder = self.path.buildFolder
+        isDirectory = false
+        guard
+            manager.fileExists(atPath: buildFolder.path, isDirectory: &isDirectory), isDirectory.boolValue
+        else {
+            throw GenerationError.invalidGeneration(
+                message: "The build folder does not exist. Have you generated the VHDL files?"
+            )
+        }
+        let vhdlFiles = try manager.contentsOfDirectory(
+            at: self.path.vhdlFolder, includingPropertiesForKeys: nil
+        )
+        guard vhdlFiles.allSatisfy({ $0.lastPathComponent.hasSuffix(".vhd") }) else {
+            throw GenerationError.invalidGeneration(
+                message: "The build folder is corrupted! Please regenerate the VHDL files."
+            )
+        }
+        guard vivado else {
+            try self.installLocal(files: vhdlFiles, manager: manager, installLocation: self.installURL)
+            return
+        }
+        try self.installVivado(files: vhdlFiles, manager: manager)
+    }
+
+    func installLocal(files: [URL], manager: FileManager, installLocation: URL) throws {
+        try files.forEach {
+            try manager.copyItem(
+                at: $0, to: installLocation.appendingPathComponent(
+                    $0.lastPathComponent, isDirectory: $0.hasDirectoryPath
+                )
+            )
+        }
+    }
+
+    func installVivado(files: [URL], manager: FileManager) throws {
+        let installURL = self.installURL
+        let projectFiles = try manager.contentsOfDirectory(at: installURL, includingPropertiesForKeys: nil)
+        guard let projectNameURL = projectFiles.first(
+            where: { $0.lastPathComponent.hasSuffix(".xpr") }
+        ) else {
+            throw GenerationError.invalidInput(
+                message: "The install directory is not a valid vivado project."
+            )
+        }
+        let projectName = String(projectNameURL.path.dropLast(4))
+        let installLocation = installURL.appendingPathComponent(
+            "\(projectName).srcs/sources_1/new", isDirectory: true
+        )
+        var isDirectory: ObjCBool = false
+        guard
+            manager.fileExists(atPath: installLocation.path, isDirectory: &isDirectory), isDirectory.boolValue
+        else {
+            throw GenerationError.invalidInput(message: "The vivado project is not set up correctly.")
+        }
+        try self.installLocal(files: files, manager: manager, installLocation: installLocation)
+    }
+
+}

--- a/Sources/MachineGenerator/InstallCommand.swift
+++ b/Sources/MachineGenerator/InstallCommand.swift
@@ -142,7 +142,7 @@ struct InstallCommand: ParsableCommand {
                 message: "The install directory is not a valid vivado project."
             )
         }
-        let projectName = String(projectNameURL.path.dropLast(4))
+        let projectName = String(projectNameURL.lastPathComponent.dropLast(4))
         let installLocation = installURL.appendingPathComponent(
             "\(projectName).srcs/sources_1/new", isDirectory: true
         )

--- a/Sources/MachineGenerator/InstallCommand.swift
+++ b/Sources/MachineGenerator/InstallCommand.swift
@@ -76,6 +76,7 @@ struct InstallCommand: ParsableCommand {
     @Flag(help: "Specifies that the install path is a vivado project directory.")
     var vivado = false
 
+    /// A `URL` of the `installPath`.
     var installURL: URL {
         URL(fileURLWithPath: installPath, isDirectory: true)
     }
@@ -135,7 +136,7 @@ struct InstallCommand: ParsableCommand {
         let installURL = self.installURL
         let projectFiles = try manager.contentsOfDirectory(at: installURL, includingPropertiesForKeys: nil)
         guard let projectNameURL = projectFiles.first(
-            where: { $0.lastPathComponent.hasSuffix(".xpr") }
+            where: { !$0.hasDirectoryPath && $0.lastPathComponent.hasSuffix(".xpr") }
         ) else {
             throw GenerationError.invalidInput(
                 message: "The install directory is not a valid vivado project."

--- a/Sources/MachineGenerator/InstallCommand.swift
+++ b/Sources/MachineGenerator/InstallCommand.swift
@@ -56,7 +56,7 @@
 import ArgumentParser
 import Foundation
 
-/// A command that install generated files into a specified directory.
+/// A command that installs generated files into a specified directory.
 struct InstallCommand: ParsableCommand {
 
     /// The configuration of this command.
@@ -77,12 +77,13 @@ struct InstallCommand: ParsableCommand {
     var installPath: String
 
     /// A `URL` of the `installPath`.
-    var installURL: URL {
+    @inlinable var installURL: URL {
         URL(fileURLWithPath: installPath, isDirectory: true)
     }
 
     /// The main entry point for this command.
     /// - Throws: ``GenerationError``.
+    @inlinable
     func run() throws {
         guard self.path.path.trimmingCharacters(in: .whitespacesAndNewlines).hasSuffix(".machine") else {
             throw GenerationError.invalidMachine(message: "The path provided is not a machine.")
@@ -122,6 +123,13 @@ struct InstallCommand: ParsableCommand {
         try self.installLocal(files: vhdlFiles, manager: manager, installLocation: self.installURL)
     }
 
+    /// Install files into a local location on the file system.
+    /// - Parameters:
+    ///   - files: The files to copy into the new location.
+    ///   - manager: The manager to perform the copy operation.
+    ///   - installLocation: The new location of the files.
+    /// - Throws: ``GenerationError``.
+    @inlinable
     func installLocal(files: [URL], manager: FileManager, installLocation: URL) throws {
         try files.forEach {
             try manager.copyItem(
@@ -132,6 +140,14 @@ struct InstallCommand: ParsableCommand {
         }
     }
 
+    /// Install files into a vivado project. This function assumed the files are VHDL files with the `.vhd`
+    /// extension. The files will be copied into `<vivado_project>.srcs/sources_1/new`. This function assumes
+    /// that the `installURL` property contains the location of the vivado project.
+    /// - Parameters:
+    ///   - files: The files to copy into the vivado project.
+    ///   - manager: The manager to perform the copy.
+    /// - Throws: ``GenerationError``.
+    @inlinable
     func installVivado(files: [URL], manager: FileManager) throws {
         let installURL = self.installURL
         let projectFiles = try manager.contentsOfDirectory(at: installURL, includingPropertiesForKeys: nil)

--- a/Sources/MachineGenerator/LLFSMGenerate.swift
+++ b/Sources/MachineGenerator/LLFSMGenerate.swift
@@ -65,7 +65,7 @@ struct LLFSMGenerate: ParsableCommand {
         commandName: "llfsmgenerate",
         abstract: "A utility for performing operations on LLFSM formats.",
         version: "1.2.0",
-        subcommands: [Generate.self, VHDLGenerator.self, CleanCommand.self]
+        subcommands: [Generate.self, VHDLGenerator.self, CleanCommand.self, InstallCommand.self]
     )
 
 }

--- a/Sources/MachineGenerator/PathArgument.swift
+++ b/Sources/MachineGenerator/PathArgument.swift
@@ -79,4 +79,9 @@ struct PathArgument: ParsableArguments {
         pathURL.appendingPathComponent("build", isDirectory: true)
     }
 
+    /// The path to the vhdl folder.
+    var vhdlFolder: URL {
+        buildFolder.appendingPathComponent("vhdl", isDirectory: true)
+    }
+
 }

--- a/Sources/MachineGenerator/VHDLGenerator.swift
+++ b/Sources/MachineGenerator/VHDLGenerator.swift
@@ -96,10 +96,11 @@ struct VHDLGenerator: ParsableCommand {
         let buildFolder = machinePath.appendingPathComponent("build", isDirectory: true)
         guard includeKripkeStructure else {
             let file = VHDLFile(representation: representation)
-            let vhdlPath = buildFolder.appendingPathComponent(
+            let vhdlFolder = buildFolder.appendingPathComponent("vhdl", isDirectory: true)
+            let vhdlPath = vhdlFolder.appendingPathComponent(
                 "\(machine.name.rawValue).vhd", isDirectory: false
             )
-            try FileManager.default.createDirectory(at: buildFolder, withIntermediateDirectories: true)
+            try FileManager.default.createDirectory(at: vhdlFolder, withIntermediateDirectories: true)
             try (file.rawValue + "\n").write(to: vhdlPath, atomically: true, encoding: .utf8)
             return
         }

--- a/Tests/MachineGeneratorTests/CleanCommandTests.swift
+++ b/Tests/MachineGeneratorTests/CleanCommandTests.swift
@@ -59,9 +59,6 @@ import XCTest
 /// Test class for ``CleanCommand``.
 final class CleanCommandTests: MachineTester {
 
-    /// A file manager.
-    let manager = FileManager.default
-
     /// Build the machine before every test.
     override func setUp() {
         super.setUp()

--- a/Tests/MachineGeneratorTests/GenerationErrorTests.swift
+++ b/Tests/MachineGeneratorTests/GenerationErrorTests.swift
@@ -1,5 +1,5 @@
-// GenerationError.swift
-// VHDLMachineTransformations
+// GenerationErrorTests.swift
+// LLFSMGenerate
 // 
 // Created by Morgan McColl.
 // Copyright © 2024 Morgan McColl. All rights reserved.
@@ -52,36 +52,21 @@
 // along with this program; if not, see http://www.gnu.org/licenses/
 // or write to the Free Software Foundation, Inc., 51 Franklin Street,
 // Fifth Floor, Boston, MA  02110-1301, USA.
-// 
 
-/// Errors thrown by the generator.
-enum GenerationError: Error, Equatable, Codable, Hashable, Sendable, CustomStringConvertible {
+@testable import MachineGenerator
+import XCTest
 
-    /// An error with the current machine.
-    case invalidMachine(message: String)
+/// Test class for ``GenerationError``.
+final class GenerationErrorTests: XCTestCase {
 
-    /// An error during the model generation process.
-    case invalidExportation(message: String)
-
-    /// An error with the current generated format.
-    case invalidFormat(message: String)
-
-    /// An error during the Machine generation process.
-    case invalidGeneration(message: String)
-
-    /// An error with user input.
-    case invalidInput(message: String)
-
-    /// An invalid layout for new machine.
-    case invalidLayout(message: String)
-
-    /// The message contained within the error.
-    @inlinable var description: String {
-        switch self {
-        case let .invalidMachine(message), let .invalidExportation(message), let .invalidFormat(message),
-        let .invalidGeneration(message), let .invalidInput(message), let .invalidLayout(message):
-            return "\(message)"
-        }
+    /// Test that the description gets the message correctly.
+    func testDescription() {
+        XCTAssertEqual(GenerationError.invalidExportation(message: "A").description, "A")
+        XCTAssertEqual(GenerationError.invalidFormat(message: "B").description, "B")
+        XCTAssertEqual(GenerationError.invalidGeneration(message: "C").description, "C")
+        XCTAssertEqual(GenerationError.invalidInput(message: "D").description, "D")
+        XCTAssertEqual(GenerationError.invalidLayout(message: "E").description, "E")
+        XCTAssertEqual(GenerationError.invalidMachine(message: "F").description, "F")
     }
 
 }

--- a/Tests/MachineGeneratorTests/GeneratorTests.swift
+++ b/Tests/MachineGeneratorTests/GeneratorTests.swift
@@ -189,8 +189,6 @@ final class GeneratorTests: MachineTester {
 
     /// Test that `run` correctly generates model.
     func testRunGeneratesModel() throws {
-        print("In test!")
-        fflush(stdout)
         let oldData = try Data(contentsOf: modelFile)
         let oldModel = try decoder.decode(MachineModel.self, from: oldData)
         var invalidModel = oldModel

--- a/Tests/MachineGeneratorTests/InstallCommandTests.swift
+++ b/Tests/MachineGeneratorTests/InstallCommandTests.swift
@@ -102,6 +102,10 @@ final class InstallCommandTests: MachineTester {
 
     /// Test files are copied correctly.
     func testInstallCommandWorksLocally() throws {
+        try manager.removeItem(
+            at: self.vivadoPath.appendingPathComponent("\(vivadoName).srcs", isDirectory: true)
+        )
+        let previousProjectContents = try String(contentsOf: self.projectFilePath, encoding: .utf8)
         InstallCommand.main([self.machine0Path.path, self.vivadoPath.path])
         let vhdlFilePath = self.buildFolder.appendingPathComponent("vhdl/Machine0.vhd", isDirectory: false)
         let contents = try String(contentsOf: vhdlFilePath, encoding: .utf8)
@@ -109,14 +113,18 @@ final class InstallCommandTests: MachineTester {
         let vivadoContents = try String(contentsOf: vivadoVHDLFile, encoding: .utf8)
         XCTAssertEqual(contents, vivadoContents)
         let files = try self.manager.contentsOfDirectory(at: self.vivadoPath, includingPropertiesForKeys: nil)
-        XCTAssertEqual(files.count, 3)
-        let expected: Set<URL> = [
-            self.projectFilePath,
-            vivadoVHDLFile,
-            self.vivadoPath.appendingPathComponent("\(vivadoName).xpr", isDirectory: false)
-        ]
+        XCTAssertEqual(files.count, 2)
+        let expected: Set<URL> = [self.projectFilePath, vivadoVHDLFile]
         XCTAssertTrue(files.allSatisfy { expected.contains($0) })
-        XCTAssertEqual(Set(files).count, 3)
+        XCTAssertEqual(Set(files).count, 2)
+        XCTAssertEqual(
+            try String(
+                contentsOf: self.buildFolder.appendingPathComponent("vhdl/Machine0.vhd", isDirectory: false),
+                encoding: .utf8
+            ),
+            try String(contentsOf: vivadoVHDLFile, encoding: .utf8)
+        )
+        XCTAssertEqual(previousProjectContents, try String(contentsOf: self.projectFilePath, encoding: .utf8))
     }
 
 }

--- a/Tests/MachineGeneratorTests/InstallCommandTests.swift
+++ b/Tests/MachineGeneratorTests/InstallCommandTests.swift
@@ -1,0 +1,123 @@
+// InstallCommandTests.swift
+// LLFSMGenerate
+// 
+// Created by Morgan McColl.
+// Copyright © 2024 Morgan McColl. All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 
+// 1. Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+// 
+// 2. Redistributions in binary form must reproduce the above
+//    copyright notice, this list of conditions and the following
+//    disclaimer in the documentation and/or other materials
+//    provided with the distribution.
+// 
+// 3. All advertising materials mentioning features or use of this
+//    software must display the following acknowledgement:
+// 
+//    This product includes software developed by Morgan McColl.
+// 
+// 4. Neither the name of the author nor the names of contributors
+//    may be used to endorse or promote products derived from this
+//    software without specific prior written permission.
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER
+// OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// 
+// -----------------------------------------------------------------------
+// This program is free software; you can redistribute it and/or
+// modify it under the above terms or under the terms of the GNU
+// General Public License as published by the Free Software Foundation;
+// either version 2 of the License, or (at your option) any later version.
+// 
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+// 
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, see http://www.gnu.org/licenses/
+// or write to the Free Software Foundation, Inc., 51 Franklin Street,
+// Fifth Floor, Boston, MA  02110-1301, USA.
+
+import ArgumentParser
+import Foundation
+@testable import MachineGenerator
+import XCTest
+
+/// Test class for ``InstallCommand``.
+final class InstallCommandTests: MachineTester {
+
+    /// The name of the vivado project.
+    let vivadoName = "Project1"
+
+    /// The path to the vivado project.
+    var vivadoPath: URL {
+        self.machinesFolder.appendingPathComponent("vivado_project", isDirectory: true)
+    }
+
+    /// The path to the destination of the VHDL sources.
+    var vhdlSourcesPath: URL {
+        self.vivadoPath.appendingPathComponent("\(vivadoName).srcs/sources_1/new", isDirectory: true)
+    }
+
+    /// The path to the project file.
+    var projectFilePath: URL {
+        self.vivadoPath.appendingPathComponent("\(vivadoName).xpr", isDirectory: false)
+    }
+
+    /// Setup install locations before every run.
+    override func setUp() {
+        super.setUp()
+        guard
+            (try? self.manager.createDirectory(at: vivadoPath, withIntermediateDirectories: true)) != nil,
+            manager.createFile(atPath: self.projectFilePath.path, contents: nil),
+            (try? self.manager.createDirectory(at: vhdlSourcesPath, withIntermediateDirectories: true)) != nil
+        else {
+            XCTFail("Failed to create vivado project.")
+            return
+        }
+        Generate.main([self.machine0Path.path])
+        VHDLGenerator.main([self.machine0Path.path])
+    }
+
+    /// Remove install locations.
+    override func tearDown() {
+        super.tearDown()
+        try? self.manager.removeItem(at: vivadoPath)
+    }
+
+    /// Test files are copied correctly.
+    func testInstallCommandWorksLocally() throws {
+        print(self.machine0Path.path)
+        InstallCommand.main([self.machine0Path.path, self.vivadoPath.path])
+        let vhdlFilePath = self.buildFolder.appendingPathComponent("vhdl/Machine0.vhd", isDirectory: false)
+        let contents = try String(contentsOf: vhdlFilePath, encoding: .utf8)
+        let vivadoVHDLFile = self.vivadoPath.appendingPathComponent("Machine0.vhd", isDirectory: false)
+        let vivadoContents = try String(contentsOf: vivadoVHDLFile, encoding: .utf8)
+        XCTAssertEqual(contents, vivadoContents)
+        let files = try self.manager.contentsOfDirectory(at: self.vivadoPath, includingPropertiesForKeys: nil)
+        XCTAssertEqual(files.count, 3)
+        let expected: Set<URL> = [
+            self.projectFilePath,
+            vivadoVHDLFile,
+            self.vivadoPath.appendingPathComponent("\(vivadoName).xpr", isDirectory: false)
+        ]
+        XCTAssertTrue(files.allSatisfy { expected.contains($0) })
+        XCTAssertEqual(Set(files).count, 3)
+    }
+
+}

--- a/Tests/MachineGeneratorTests/InstallCommandTests.swift
+++ b/Tests/MachineGeneratorTests/InstallCommandTests.swift
@@ -97,12 +97,11 @@ final class InstallCommandTests: MachineTester {
     /// Remove install locations.
     override func tearDown() {
         super.tearDown()
-        try? self.manager.removeItem(at: vivadoPath)
+        XCTAssertNotNil(try? self.manager.removeItem(at: vivadoPath))
     }
 
     /// Test files are copied correctly.
     func testInstallCommandWorksLocally() throws {
-        print(self.machine0Path.path)
         InstallCommand.main([self.machine0Path.path, self.vivadoPath.path])
         let vhdlFilePath = self.buildFolder.appendingPathComponent("vhdl/Machine0.vhd", isDirectory: false)
         let contents = try String(contentsOf: vhdlFilePath, encoding: .utf8)

--- a/Tests/MachineGeneratorTests/LLFSMGenerateTests.swift
+++ b/Tests/MachineGeneratorTests/LLFSMGenerateTests.swift
@@ -78,7 +78,7 @@ final class LLFSMGenerateTests: MachineTester {
     func testRunCallsVHDL() throws {
         LLFSMGenerate.main(["vhdl", self.pathRaw])
         let manager = FileManager.default
-        let path = pathRaw + "/build/Machine0.vhd"
+        let path = pathRaw + "/build/vhdl/Machine0.vhd"
         defer { _ = try? manager.removeItem(at: URL(fileURLWithPath: path, isDirectory: false)) }
         XCTAssertTrue(manager.fileExists(atPath: path))
     }

--- a/Tests/MachineGeneratorTests/MachineTester.swift
+++ b/Tests/MachineGeneratorTests/MachineTester.swift
@@ -68,6 +68,9 @@ class MachineTester: XCTestCase {
     /// A JSON decoder.
     let decoder = JSONDecoder()
 
+    /// A `FileManager`.
+    let manager = FileManager.default
+
     /// A path to Machine0.
     var pathRaw: String {
         String(packagePath) + "/Tests/MachineGeneratorTests/machines/Machine0.machine"
@@ -110,7 +113,7 @@ class MachineTester: XCTestCase {
 
     /// Create test machines before every test.
     override func setUp() {
-        let createDir: ()? = try? FileManager.default
+        let createDir: ()? = try? manager
             .createDirectory(at: machine0Path, withIntermediateDirectories: true)
         guard
             createDir != nil,

--- a/Tests/MachineGeneratorTests/PathArgumentTests.swift
+++ b/Tests/MachineGeneratorTests/PathArgumentTests.swift
@@ -1,5 +1,5 @@
-// PathArgument.swift
-// VHDLMachineTransformations
+// PathArgumentTests.swift
+// LLFSMGenerate
 // 
 // Created by Morgan McColl.
 // Copyright © 2024 Morgan McColl. All rights reserved.
@@ -52,36 +52,39 @@
 // along with this program; if not, see http://www.gnu.org/licenses/
 // or write to the Free Software Foundation, Inc., 51 Franklin Street,
 // Fifth Floor, Boston, MA  02110-1301, USA.
-// 
 
 import ArgumentParser
 import Foundation
+@testable import MachineGenerator
+import XCTest
 
-/// A struct defining the shared arguments for the machine generator.
-struct PathArgument: ParsableArguments {
+/// Test class for ``PathArgument``.
+final class PathArgumentTests: XCTestCase {
 
-    /// The path to the machine folder.
-    @Argument(help: "The path to the machine folder.", completion: .directory)
-    var path: String
-
-    /// The path to the machine file.
-    @inlinable var machine: URL {
-        pathURL.appendingPathComponent("machine.json", isDirectory: false)
+    /// A command with a path.
+    var command: Generate {
+        get throws {
+            try Generate.parse(["path"])
+        }
     }
 
-    /// The path to the users input (the machine folder).
-    @inlinable var pathURL: URL {
-        URL(fileURLWithPath: path, isDirectory: true)
+    /// The argument under test.
+    var argument: PathArgument {
+        get throws {
+            try command.options
+        }
     }
 
-    /// The path to the build folder.
-    @inlinable var buildFolder: URL {
-        pathURL.appendingPathComponent("build", isDirectory: true)
-    }
-
-    /// The path to the vhdl folder.
-    @inlinable var vhdlFolder: URL {
-        buildFolder.appendingPathComponent("vhdl", isDirectory: true)
+    /// Test that the computed properties are correct.
+    func testComputedProperties() throws {
+        let url = URL(fileURLWithPath: "path", isDirectory: true)
+        XCTAssertEqual(try argument.pathURL, url)
+        let machine = url.appendingPathComponent("machine.json", isDirectory: false)
+        XCTAssertEqual(try argument.machine, machine)
+        let build = url.appendingPathComponent("build", isDirectory: true)
+        XCTAssertEqual(try argument.buildFolder, build)
+        let vhdl = build.appendingPathComponent("vhdl", isDirectory: true)
+        XCTAssertEqual(try argument.vhdlFolder, vhdl)
     }
 
 }

--- a/Tests/MachineGeneratorTests/VHDLGeneratorTests.swift
+++ b/Tests/MachineGeneratorTests/VHDLGeneratorTests.swift
@@ -78,7 +78,7 @@ final class VHDLGeneratorTests: MachineTester {
             return
         }
         VHDLGenerator.main([pathRaw])
-        let vhdlPath = machine0Path.appendingPathComponent("build/Machine0.vhd", isDirectory: false)
+        let vhdlPath = machine0Path.appendingPathComponent("build/vhdl/Machine0.vhd", isDirectory: false)
         guard let representation = MachineRepresentation(machine: machine) else {
             XCTFail("Failed to create VHDL for machine.")
             return


### PR DESCRIPTION
The `install` subcommand allows the generated VHDL files to be copied into a specified directory. This command also supports installation into vivado projects by specifying the location of the vivado project with the `--vivado` flag present.