### PR TITLE
Add Report command for listing human-readable information about machines

### DIFF
--- a/Sources/GeneratorCommands/LLFSMGenerate.swift
+++ b/Sources/GeneratorCommands/LLFSMGenerate.swift
@@ -66,7 +66,7 @@ public struct LLFSMGenerate: ParsableCommand {
         version: "3.0.0",
         subcommands: [
             Generate.self, VHDLGenerator.self, CleanCommand.self, InstallCommand.self, GraphCommand.self,
-            ReportCommand.self
+            ReportCommand.self,
         ]
     )
 

--- a/Sources/GeneratorCommands/LLFSMGenerate.swift
+++ b/Sources/GeneratorCommands/LLFSMGenerate.swift
@@ -66,6 +66,7 @@ public struct LLFSMGenerate: ParsableCommand {
         version: "3.0.0",
         subcommands: [
             Generate.self, VHDLGenerator.self, CleanCommand.self, InstallCommand.self, GraphCommand.self,
+            ReportCommand.self
         ]
     )
 

--- a/Sources/GeneratorCommands/ReportCommand.swift
+++ b/Sources/GeneratorCommands/ReportCommand.swift
@@ -1,0 +1,194 @@
+// ReportCommand.swift
+// LLFSMGenerate
+//
+// Created by Morgan McColl.
+// Copyright © 2024 Morgan McColl. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+//
+// 1. Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above
+//    copyright notice, this list of conditions and the following
+//    disclaimer in the documentation and/or other materials
+//    provided with the distribution.
+//
+// 3. All advertising materials mentioning features or use of this
+//    software must display the following acknowledgement:
+//
+//    This product includes software developed by Morgan McColl.
+//
+// 4. Neither the name of the author nor the names of contributors
+//    may be used to endorse or promote products derived from this
+//    software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER
+// OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// -----------------------------------------------------------------------
+// This program is free software; you can redistribute it and/or
+// modify it under the above terms or under the terms of the GNU
+// General Public License as published by the Free Software Foundation;
+// either version 2 of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, see http://www.gnu.org/licenses/
+// or write to the Free Software Foundation, Inc., 51 Franklin Street,
+// Fifth Floor, Boston, MA  02110-1301, USA.
+
+import ArgumentParser
+import Foundation
+import JavascriptModel
+import StringHelpers
+import VHDLKripkeStructures
+
+public struct ReportCommand: ParsableCommand {
+
+    /// The command configuration.
+    public static var configuration = CommandConfiguration(
+        commandName: "report",
+        abstract: "Report Statistics about the generated machine."
+    )
+
+    @inlinable var decoder: JSONDecoder {
+        JSONDecoder()
+    }
+
+    @inlinable var manager: FileManager {
+        FileManager.default
+    }
+
+    /// A path to the machine to report.
+    @OptionGroup @usableFromInline var path: PathArgument
+
+    @Option(name: .shortAndLong, help: "The output file to write the report to.")
+    @usableFromInline var output: String?
+
+    @inlinable var outputURL: URL? {
+        output.flatMap { URL(fileURLWithPath: $0, isDirectory: false) }
+    }
+
+    @inlinable var kripkeStructureURL: URL {
+        path.pathURL.appending(component: "output.json", directoryHint: .notDirectory)
+    }
+
+    /// Default init.
+    @inlinable
+    public init() {}
+
+    public func run() throws {
+        let structurePath = self.kripkeStructureURL.path
+        let data = try Data(contentsOf: path.pathURL.appendingPathComponent("model.json", isDirectory: false))
+        let machine = try decoder.decode(MachineModel.self, from: data)
+        let machineReport = String(reportForMachine: machine, name: path.pathURL.lastPathComponent)
+        guard manager.fileExists(atPath: structurePath) else {
+            try writeReport(report: machineReport)
+            return
+        }
+        let structureData = try Data(contentsOf: kripkeStructureURL)
+        let kripkeStructure = try decoder.decode(KripkeStructure.self, from: structureData)
+        let structureReport = String(reportForStructure: kripkeStructure)
+        let report = """
+        - Machine:
+        \(machineReport.indent(amount: 1))
+        - Kripke Structure:
+        \(structureReport.indent(amount: 1))
+        """
+        try writeReport(report: report)
+    }
+
+    func writeReport(report: String) throws {
+        guard let outputURL else {
+            print(report)
+            return
+        }
+        try report.write(to: outputURL, atomically: true, encoding: .utf8)
+    }
+
+}
+
+extension String {
+
+    init(reportForMachine machine: MachineModel, name: String) {
+        let stateData = machine.states.map { state in
+            let actions = state.actions.compactMap {
+                guard !$0.code.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+                    return nil
+                }
+                return """
+                - \($0.name):
+                \($0.code.indent(amount: 1))
+                """
+            }
+            .joined(separator: "\n\n")
+            let transitions = machine.transitions.filter { $0.source == state.name }
+                .enumerated()
+                .map {
+                    "- \($0): \($1.condition)"
+                }
+                .joined(separator: "\n")
+            let stateInfo = """
+            \(String(category: "External Variables", data: state.externalVariables))
+            \(String(category: "State Variables", data: state.variables))
+            \(String(category: "Actions", data: actions))
+            \(String(category: "Transitions", data: transitions))
+            """
+            return String(category: state.name, data: stateInfo)
+        }
+        let clockData = machine.clocks.map {
+            """
+            - \($0.name) \($0.frequency)
+            """
+        }
+        .joined(separator: "\n")
+        let machineInfo = """
+        \(String(category: "External Variables", data: machine.externalVariables))
+        \(String(category: "Machine Variables", data: machine.machineVariables))
+        \(String(category: "Clocks", data: clockData))
+        \(String(category: "States", data: stateData.joined(separator: "\n")))
+        \(String(category: "Initial State", data: machine.initialState))
+        \(String(category: "Suspended State", data: machine.suspendedState ?? ""))
+        \(String(category: "Includes", data: machine.includes))
+        """
+        self.init(category: name, data: machineInfo)
+    }
+
+    init(reportForStructure structure: KripkeStructure) {
+        let nodes = structure.nodes.count
+        let edges = structure.edges.values.reduce(0) { $0 + $1.count }
+        let data = """
+        - Nodes: \(nodes)
+        - Edges: \(edges)
+        """
+        self.init(category: "Kripke Structure", data: data)
+    }
+
+    init(category: String, data: String) {
+        if data.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            self = "- \(category):"
+        } else {
+            self = """
+            - \(category):
+            \(data.indent(amount: 1))
+            """
+        }
+    }
+
+}

--- a/Sources/GeneratorCommands/ReportCommand.swift
+++ b/Sources/GeneratorCommands/ReportCommand.swift
@@ -60,7 +60,7 @@ import StringHelpers
 import VHDLKripkeStructures
 
 /// A command to produce human-readable information about an LLFSM.
-/// 
+///
 /// This struct allows the generation of human-readable reports detailing the code within an LLFSM and other
 /// statistics about the machine.
 public struct ReportCommand: ParsableCommand {
@@ -120,10 +120,10 @@ public struct ReportCommand: ParsableCommand {
         let kripkeStructure = try decoder.decode(KripkeStructure.self, from: structureData)
         let structureReport = String(reportForStructure: kripkeStructure)
         let report = """
-        \(String(category: "Machine", data: machineReport))
-        \(String(category: "Kripke Structure", data: structureReport))
+            \(String(category: "Machine", data: machineReport))
+            \(String(category: "Kripke Structure", data: structureReport))
 
-        """
+            """
         try writeReport(report: report)
     }
 
@@ -161,16 +161,17 @@ extension String {
     @inlinable
     init(reportForMachine machine: MachineModel, name: String) {
         let stateData = machine.states.map { state in
-            let actions = state.actions.compactMap {
-                guard !$0.code.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
-                    return nil
+            let actions = state.actions
+                .compactMap {
+                    guard !$0.code.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+                        return nil
+                    }
+                    return """
+                        - \($0.name):
+                        \($0.code.indent(amount: 1))
+                        """
                 }
-                return """
-                - \($0.name):
-                \($0.code.indent(amount: 1))
-                """
-            }
-            .joined(separator: "\n\n")
+                .joined(separator: "\n\n")
             let transitions = machine.transitions.filter { $0.source == state.name }
                 .enumerated()
                 .map {
@@ -178,28 +179,29 @@ extension String {
                 }
                 .joined(separator: "\n")
             let stateInfo = """
-            \(String(category: "External Variables", data: state.externalVariables))
-            \(String(category: "State Variables", data: state.variables))
-            \(String(category: "Actions", data: actions))
-            \(String(category: "Transitions", data: transitions))
-            """
+                \(String(category: "External Variables", data: state.externalVariables))
+                \(String(category: "State Variables", data: state.variables))
+                \(String(category: "Actions", data: actions))
+                \(String(category: "Transitions", data: transitions))
+                """
             return String(category: state.name, data: stateInfo)
         }
-        let clockData = machine.clocks.map {
-            """
-            - \($0.name) \($0.frequency)
-            """
-        }
-        .joined(separator: "\n")
+        let clockData = machine.clocks
+            .map {
+                """
+                - \($0.name) \($0.frequency)
+                """
+            }
+            .joined(separator: "\n")
         let machineInfo = """
-        \(String(category: "External Variables", data: machine.externalVariables))
-        \(String(category: "Machine Variables", data: machine.machineVariables))
-        \(String(category: "Clocks", data: clockData))
-        \(String(category: "States", data: stateData.joined(separator: "\n")))
-        \(String(category: "Initial State", data: machine.initialState))
-        \(String(category: "Suspended State", data: machine.suspendedState ?? ""))
-        \(String(category: "Includes", data: machine.includes))
-        """
+            \(String(category: "External Variables", data: machine.externalVariables))
+            \(String(category: "Machine Variables", data: machine.machineVariables))
+            \(String(category: "Clocks", data: clockData))
+            \(String(category: "States", data: stateData.joined(separator: "\n")))
+            \(String(category: "Initial State", data: machine.initialState))
+            \(String(category: "Suspended State", data: machine.suspendedState ?? ""))
+            \(String(category: "Includes", data: machine.includes))
+            """
         self.init(category: name, data: machineInfo)
     }
 
@@ -212,9 +214,9 @@ extension String {
         let nodes = structure.nodes.count
         let edges = structure.edges.values.reduce(0) { $0 + $1.count }
         let data = """
-        - Nodes: \(nodes)
-        - Edges: \(edges)
-        """
+            - Nodes: \(nodes)
+            - Edges: \(edges)
+            """
         self.init(category: "Kripke Structure", data: data)
     }
 
@@ -237,9 +239,9 @@ extension String {
             self = "- \(category):"
         } else {
             self = """
-            - \(category):
-            \(data.indent(amount: 1))
-            """
+                - \(category):
+                \(data.indent(amount: 1))
+                """
         }
     }
 

--- a/Sources/GeneratorCommands/ReportCommand.swift
+++ b/Sources/GeneratorCommands/ReportCommand.swift
@@ -95,7 +95,7 @@ public struct ReportCommand: ParsableCommand {
 
     /// The default path to the generated kripke structure.
     @inlinable var kripkeStructureURL: URL {
-        path.pathURL.appending(component: "output.json", directoryHint: .notDirectory)
+        path.pathURL.appendingPathComponent("output.json", isDirectory: false)
     }
 
     /// Default init.

--- a/Sources/GeneratorCommands/ReportCommand.swift
+++ b/Sources/GeneratorCommands/ReportCommand.swift
@@ -99,7 +99,7 @@ public struct ReportCommand: ParsableCommand {
         let machine = try decoder.decode(MachineModel.self, from: data)
         let machineReport = String(reportForMachine: machine, name: path.pathURL.lastPathComponent)
         guard manager.fileExists(atPath: structurePath) else {
-            try writeReport(report: String(category: "Machine", data: machineReport))
+            try writeReport(report: String(category: "Machine", data: machineReport) + "\n")
             return
         }
         let structureData = try Data(contentsOf: kripkeStructureURL)
@@ -108,6 +108,7 @@ public struct ReportCommand: ParsableCommand {
         let report = """
         \(String(category: "Machine", data: machineReport))
         \(String(category: "Kripke Structure", data: structureReport))
+
         """
         try writeReport(report: report)
     }

--- a/Sources/GeneratorCommands/ReportCommand.swift
+++ b/Sources/GeneratorCommands/ReportCommand.swift
@@ -99,17 +99,15 @@ public struct ReportCommand: ParsableCommand {
         let machine = try decoder.decode(MachineModel.self, from: data)
         let machineReport = String(reportForMachine: machine, name: path.pathURL.lastPathComponent)
         guard manager.fileExists(atPath: structurePath) else {
-            try writeReport(report: machineReport)
+            try writeReport(report: String(category: "Machine", data: machineReport))
             return
         }
         let structureData = try Data(contentsOf: kripkeStructureURL)
         let kripkeStructure = try decoder.decode(KripkeStructure.self, from: structureData)
         let structureReport = String(reportForStructure: kripkeStructure)
         let report = """
-        - Machine:
-        \(machineReport.indent(amount: 1))
-        - Kripke Structure:
-        \(structureReport.indent(amount: 1))
+        \(String(category: "Machine", data: machineReport))
+        \(String(category: "Kripke Structure", data: structureReport))
         """
         try writeReport(report: report)
     }
@@ -118,6 +116,9 @@ public struct ReportCommand: ParsableCommand {
         guard let outputURL else {
             print(report)
             return
+        }
+        if manager.fileExists(atPath: outputURL.path) {
+            try manager.removeItem(at: outputURL)
         }
         try report.write(to: outputURL, atomically: true, encoding: .utf8)
     }

--- a/Tests/GeneratorTests/LLFSMGenerateTests.swift
+++ b/Tests/GeneratorTests/LLFSMGenerateTests.swift
@@ -87,7 +87,7 @@ final class LLFSMGenerateTests: MachineTester {
     /// Test sub-commands exist for parent binary.
     func testSubCommands() {
         let subcommands = LLFSMGenerate.configuration.subcommands
-        let expectedCommands = ["model", "vhdl", "clean", "install", "graph"]
+        let expectedCommands = ["model", "vhdl", "clean", "install", "graph", "report"]
         XCTAssertEqual(subcommands.map { $0._commandName }.sorted(), expectedCommands.sorted())
     }
 

--- a/Tests/GeneratorTests/ReportCommandTests.swift
+++ b/Tests/GeneratorTests/ReportCommandTests.swift
@@ -1,0 +1,146 @@
+// ReportCommandTests.swift
+// LLFSMGenerate
+// 
+// Created by Morgan McColl.
+// Copyright © 2024 Morgan McColl. All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 
+// 1. Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+// 
+// 2. Redistributions in binary form must reproduce the above
+//    copyright notice, this list of conditions and the following
+//    disclaimer in the documentation and/or other materials
+//    provided with the distribution.
+// 
+// 3. All advertising materials mentioning features or use of this
+//    software must display the following acknowledgement:
+// 
+//    This product includes software developed by Morgan McColl.
+// 
+// 4. Neither the name of the author nor the names of contributors
+//    may be used to endorse or promote products derived from this
+//    software without specific prior written permission.
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER
+// OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// 
+// -----------------------------------------------------------------------
+// This program is free software; you can redistribute it and/or
+// modify it under the above terms or under the terms of the GNU
+// General Public License as published by the Free Software Foundation;
+// either version 2 of the License, or (at your option) any later version.
+// 
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+// 
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, see http://www.gnu.org/licenses/
+// or write to the Free Software Foundation, Inc., 51 Franklin Street,
+// Fifth Floor, Boston, MA  02110-1301, USA.
+
+@testable import GeneratorCommands
+import JavascriptModel
+import TestHelpers
+import XCTest
+
+/// Test class for ``ReportCommand``.
+final class ReportCommandTests: MachineTester {
+
+    // swiftlint:disable trailing_whitespace
+
+    /// The raw string printed for `Machine0`.
+    let pingMachineRaw = """
+    - PingMachine.machine:
+        - External Variables:
+            ping: out std_logic;
+            pong: in std_logic;
+        - Machine Variables:
+        - Clocks:
+            - clk 5 MHz
+        - States:
+            - Initial:
+                - External Variables:
+                - State Variables:
+                - Actions:
+                - Transitions:
+                    - 0: true
+            - SendPing:
+                - External Variables:
+                    ping
+                - State Variables:
+                - Actions:
+                    - OnExit:
+                        ping <= '1';
+                - Transitions:
+                    - 0: true
+            - WaitForPong:
+                - External Variables:
+                    ping
+                    pong
+                - State Variables:
+                - Actions:
+                    - Internal:
+                        ping <= '0';
+                    
+                    - OnEntry:
+                        ping <= '0';
+                - Transitions:
+                    - 0: pong = '1'
+        - Initial State:
+            Initial
+        - Suspended State:
+        - Includes:
+            library IEEE;
+            use IEEE.std_logic_1164.all;
+    """
+
+    /// The report for the kripke structure.
+    let structureRaw = """
+    - Kripke Structure:
+        - Nodes: 12
+        - Edges: 13
+    """
+
+    // swiftlint:enable trailing_whitespace
+
+    /// Test the machine is encoded correctly.
+    func testMachineEncoding() throws {
+        let machine = String(reportForMachine: .pingMachine, name: "PingMachine.machine")
+        XCTAssertEqual(machine, pingMachineRaw)
+    }
+
+    /// Test the kripke structure is encoded correctly.
+    func testKripkeStructureEncoding() throws {
+        let structure = String(reportForStructure: .pingPongStructure)
+        XCTAssertEqual(structure, structureRaw)
+    }
+
+    /// Test the string category init handles data correctly.
+    func testStringCategoryInit() {
+        let data = "This is\nsome data!"
+        let withData = """
+        - Data:
+            This is
+            some data!
+        """
+        let withoutData = "- Data:"
+        XCTAssertEqual(String(category: "Data", data: data), withData)
+        XCTAssertEqual(String(category: "Data", data: ""), withoutData)
+    }
+
+}

--- a/Tests/GeneratorTests/ReportCommandTests.swift
+++ b/Tests/GeneratorTests/ReportCommandTests.swift
@@ -228,6 +228,7 @@ final class ReportCommandTests: MachineTester {
             - Kripke Structure:
                 - Nodes: 12
                 - Edges: 13
+
         """
         XCTAssertEqual(contents, expected)
     }
@@ -281,6 +282,7 @@ final class ReportCommandTests: MachineTester {
                 - Includes:
                     library IEEE;
                     use IEEE.std_logic_1164.all;
+
         """
         XCTAssertEqual(contents, expected)
     }

--- a/Tests/GeneratorTests/ReportCommandTests.swift
+++ b/Tests/GeneratorTests/ReportCommandTests.swift
@@ -1,30 +1,30 @@
 // ReportCommandTests.swift
 // LLFSMGenerate
-// 
+//
 // Created by Morgan McColl.
 // Copyright © 2024 Morgan McColl. All rights reserved.
-// 
+//
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions
 // are met:
-// 
+//
 // 1. Redistributions of source code must retain the above copyright
 //    notice, this list of conditions and the following disclaimer.
-// 
+//
 // 2. Redistributions in binary form must reproduce the above
 //    copyright notice, this list of conditions and the following
 //    disclaimer in the documentation and/or other materials
 //    provided with the distribution.
-// 
+//
 // 3. All advertising materials mentioning features or use of this
 //    software must display the following acknowledgement:
-// 
+//
 //    This product includes software developed by Morgan McColl.
-// 
+//
 // 4. Neither the name of the author nor the names of contributors
 //    may be used to endorse or promote products derived from this
 //    software without specific prior written permission.
-// 
+//
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
 // "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
 // LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
@@ -36,18 +36,18 @@
 // LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
 // NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-// 
+//
 // -----------------------------------------------------------------------
 // This program is free software; you can redistribute it and/or
 // modify it under the above terms or under the terms of the GNU
 // General Public License as published by the Free Software Foundation;
 // either version 2 of the License, or (at your option) any later version.
-// 
+//
 // This program is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 // GNU General Public License for more details.
-// 
+//
 // You should have received a copy of the GNU General Public License
 // along with this program; if not, see http://www.gnu.org/licenses/
 // or write to the Free Software Foundation, Inc., 51 Franklin Street,
@@ -65,56 +65,56 @@ final class ReportCommandTests: MachineTester {
 
     /// The raw string printed for `Machine0`.
     let pingMachineRaw = """
-    - PingMachine.machine:
-        - External Variables:
-            ping: out std_logic;
-            pong: in std_logic;
-        - Machine Variables:
-        - Clocks:
-            - clk 5 MHz
-        - States:
-            - Initial:
-                - External Variables:
-                - State Variables:
-                - Actions:
-                - Transitions:
-                    - 0: true
-            - SendPing:
-                - External Variables:
-                    ping
-                - State Variables:
-                - Actions:
-                    - OnExit:
-                        ping <= '1';
-                - Transitions:
-                    - 0: true
-            - WaitForPong:
-                - External Variables:
-                    ping
-                    pong
-                - State Variables:
-                - Actions:
-                    - Internal:
-                        ping <= '0';
-                    
-                    - OnEntry:
-                        ping <= '0';
-                - Transitions:
-                    - 0: pong = '1'
-        - Initial State:
-            Initial
-        - Suspended State:
-        - Includes:
-            library IEEE;
-            use IEEE.std_logic_1164.all;
-    """
+        - PingMachine.machine:
+            - External Variables:
+                ping: out std_logic;
+                pong: in std_logic;
+            - Machine Variables:
+            - Clocks:
+                - clk 5 MHz
+            - States:
+                - Initial:
+                    - External Variables:
+                    - State Variables:
+                    - Actions:
+                    - Transitions:
+                        - 0: true
+                - SendPing:
+                    - External Variables:
+                        ping
+                    - State Variables:
+                    - Actions:
+                        - OnExit:
+                            ping <= '1';
+                    - Transitions:
+                        - 0: true
+                - WaitForPong:
+                    - External Variables:
+                        ping
+                        pong
+                    - State Variables:
+                    - Actions:
+                        - Internal:
+                            ping <= '0';
+                        
+                        - OnEntry:
+                            ping <= '0';
+                    - Transitions:
+                        - 0: pong = '1'
+            - Initial State:
+                Initial
+            - Suspended State:
+            - Includes:
+                library IEEE;
+                use IEEE.std_logic_1164.all;
+        """
 
     /// The report for the kripke structure.
     let structureRaw = """
-    - Kripke Structure:
-        - Nodes: 12
-        - Edges: 13
-    """
+        - Kripke Structure:
+            - Nodes: 12
+            - Edges: 13
+        """
 
     // swiftlint:enable trailing_whitespace
 
@@ -145,10 +145,10 @@ final class ReportCommandTests: MachineTester {
     func testStringCategoryInit() {
         let data = "This is\nsome data!"
         let withData = """
-        - Data:
-            This is
-            some data!
-        """
+            - Data:
+                This is
+                some data!
+            """
         let withoutData = "- Data:"
         XCTAssertEqual(String(category: "Data", data: data), withData)
         XCTAssertEqual(String(category: "Data", data: ""), withoutData)
@@ -158,7 +158,8 @@ final class ReportCommandTests: MachineTester {
     func testWriteReport() throws {
         let data0 = "data0"
         let file = self.pingMachineFolder.appendingPathComponent(
-            "report_command_test.txt", isDirectory: false
+            "report_command_test.txt",
+            isDirectory: false
         )
         let printCommand = try ReportCommand.parse([self.pingMachineFolder.path])
         try printCommand.writeReport(report: data0)
@@ -181,55 +182,55 @@ final class ReportCommandTests: MachineTester {
         ReportCommand.main([self.pingMachineFolder.path, "--output", file.path])
         let contents = try String(contentsOf: file, encoding: .utf8)
         let expected = """
-        - Machine:
-            - PingMachine.machine:
-                - External Variables:
-                    ping: out std_logic;
-                    pong: in std_logic;
-                - Machine Variables:
-                - Clocks:
-                    - clk 5 MHz
-                - States:
-                    - Initial:
-                        - External Variables:
-                        - State Variables:
-                        - Actions:
-                        - Transitions:
-                            - 0: true
-                    - SendPing:
-                        - External Variables:
-                            ping
-                        - State Variables:
-                        - Actions:
-                            - OnExit:
-                                ping <= '1';
-                        - Transitions:
-                            - 0: true
-                    - WaitForPong:
-                        - External Variables:
-                            ping
-                            pong
-                        - State Variables:
-                        - Actions:
-                            - Internal:
-                                ping <= '0';
-                            
-                            - OnEntry:
-                                ping <= '0';
-                        - Transitions:
-                            - 0: pong = '1'
-                - Initial State:
-                    Initial
-                - Suspended State:
-                - Includes:
-                    library IEEE;
-                    use IEEE.std_logic_1164.all;
-        - Kripke Structure:
+            - Machine:
+                - PingMachine.machine:
+                    - External Variables:
+                        ping: out std_logic;
+                        pong: in std_logic;
+                    - Machine Variables:
+                    - Clocks:
+                        - clk 5 MHz
+                    - States:
+                        - Initial:
+                            - External Variables:
+                            - State Variables:
+                            - Actions:
+                            - Transitions:
+                                - 0: true
+                        - SendPing:
+                            - External Variables:
+                                ping
+                            - State Variables:
+                            - Actions:
+                                - OnExit:
+                                    ping <= '1';
+                            - Transitions:
+                                - 0: true
+                        - WaitForPong:
+                            - External Variables:
+                                ping
+                                pong
+                            - State Variables:
+                            - Actions:
+                                - Internal:
+                                    ping <= '0';
+                                
+                                - OnEntry:
+                                    ping <= '0';
+                            - Transitions:
+                                - 0: pong = '1'
+                    - Initial State:
+                        Initial
+                    - Suspended State:
+                    - Includes:
+                        library IEEE;
+                        use IEEE.std_logic_1164.all;
             - Kripke Structure:
-                - Nodes: 12
-                - Edges: 13
+                - Kripke Structure:
+                    - Nodes: 12
+                    - Edges: 13
 
-        """
+            """
         XCTAssertEqual(contents, expected)
     }
 
@@ -239,51 +240,51 @@ final class ReportCommandTests: MachineTester {
         ReportCommand.main([self.pingMachineFolder.path, "--output", file.path])
         let contents = try String(contentsOf: file, encoding: .utf8)
         let expected = """
-        - Machine:
-            - PingMachine.machine:
-                - External Variables:
-                    ping: out std_logic;
-                    pong: in std_logic;
-                - Machine Variables:
-                - Clocks:
-                    - clk 5 MHz
-                - States:
-                    - Initial:
-                        - External Variables:
-                        - State Variables:
-                        - Actions:
-                        - Transitions:
-                            - 0: true
-                    - SendPing:
-                        - External Variables:
-                            ping
-                        - State Variables:
-                        - Actions:
-                            - OnExit:
-                                ping <= '1';
-                        - Transitions:
-                            - 0: true
-                    - WaitForPong:
-                        - External Variables:
-                            ping
-                            pong
-                        - State Variables:
-                        - Actions:
-                            - Internal:
-                                ping <= '0';
-                            
-                            - OnEntry:
-                                ping <= '0';
-                        - Transitions:
-                            - 0: pong = '1'
-                - Initial State:
-                    Initial
-                - Suspended State:
-                - Includes:
-                    library IEEE;
-                    use IEEE.std_logic_1164.all;
+            - Machine:
+                - PingMachine.machine:
+                    - External Variables:
+                        ping: out std_logic;
+                        pong: in std_logic;
+                    - Machine Variables:
+                    - Clocks:
+                        - clk 5 MHz
+                    - States:
+                        - Initial:
+                            - External Variables:
+                            - State Variables:
+                            - Actions:
+                            - Transitions:
+                                - 0: true
+                        - SendPing:
+                            - External Variables:
+                                ping
+                            - State Variables:
+                            - Actions:
+                                - OnExit:
+                                    ping <= '1';
+                            - Transitions:
+                                - 0: true
+                        - WaitForPong:
+                            - External Variables:
+                                ping
+                                pong
+                            - State Variables:
+                            - Actions:
+                                - Internal:
+                                    ping <= '0';
+                                
+                                - OnEntry:
+                                    ping <= '0';
+                            - Transitions:
+                                - 0: pong = '1'
+                    - Initial State:
+                        Initial
+                    - Suspended State:
+                    - Includes:
+                        library IEEE;
+                        use IEEE.std_logic_1164.all;
 
-        """
+            """
         XCTAssertEqual(contents, expected)
     }
 


### PR DESCRIPTION
This PR adds a new `report` sub-command to `llfsm-generate`.

The `report` sub-command prints and optionally saves a human-readable report about a specified LLFSM. The report contains information such as the variables, states and actions within an LLFSM, and the number of nodes and edges within its Kripke structure.